### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/oxibus/can-dbc-pest/compare/v0.1.0...v0.1.1) - 2025-10-06
+
+### Other
+
+- enable release-plz CI ([#2](https://github.com/oxibus/can-dbc-pest/pull/2))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "can-dbc-pest"
-version = "0.1.0"
+version = "0.1.1"
 description = "A Pest-based parser for the DBC format. The DBC format is used to exchange CAN network data."
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/oxibus/can-dbc-pest"


### PR DESCRIPTION



## 🤖 New release

* `can-dbc-pest`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/oxibus/can-dbc-pest/compare/v0.1.0...v0.1.1) - 2025-10-06

### Other

- enable release-plz CI ([#2](https://github.com/oxibus/can-dbc-pest/pull/2))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).