### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/oxibus/can-dbc-pest/compare/v0.1.1...v0.2.0) - 2025-10-07
+
+### Fixed
+
+- improve pest, pass openocd ([#4](https://github.com/oxibus/can-dbc-pest/pull/4))
+
 ## [0.1.1](https://github.com/oxibus/can-dbc-pest/compare/v0.1.0...v0.1.1) - 2025-10-06
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- improve pest, pass openocd ([#4](https://github.com/oxibus/can-dbc-pest/pull/4))
+- improve pest, pass opendbc ([#4](https://github.com/oxibus/can-dbc-pest/pull/4))
 
 ## [0.1.1](https://github.com/oxibus/can-dbc-pest/compare/v0.1.0...v0.1.1) - 2025-10-06
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "can-dbc-pest"
-version = "0.1.1"
+version = "0.2.0"
 description = "A Pest-based parser for the DBC format. The DBC format is used to exchange CAN network data."
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/oxibus/can-dbc-pest"


### PR DESCRIPTION



## 🤖 New release

* `can-dbc-pest`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `can-dbc-pest` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Rule::number 6 -> 8 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::string 7 -> 9 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::char 8 -> 11 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::version 11 -> 14 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::new_symbols 12 -> 15 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::bit_timing 13 -> 16 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::nodes 14 -> 17 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::message 15 -> 18 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::signal 16 -> 19 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::comment 17 -> 20 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::attr_def 18 -> 21 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::attr_value 19 -> 22 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::value_table_def 20 -> 23 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::value_table 21 -> 24 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::signal_group 22 -> 25 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::signal_value_type 23 -> 26 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::bo_tx_bu 24 -> 27 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::ba_def_rel 25 -> 28 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::ba_rel 26 -> 29 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::ba_def_def_rel 27 -> 30 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::ba_def_def 28 -> 31 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::sg_mul_val 29 -> 32 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule::environment_variable 30 -> 33 in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_variant_added.ron

Failed in:
  variant Rule:int in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule:uint in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule:can_id in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule:str in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule:ident in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule:ident_ext in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  variant Rule:envvar_data in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Rule::integer, previously in file /tmp/.tmpW2nKdO/can-dbc-pest/src/lib.rs:15
  variant Rule::identifier, previously in file /tmp/.tmpW2nKdO/can-dbc-pest/src/lib.rs:15
  variant Rule::extended_identifier, previously in file /tmp/.tmpW2nKdO/can-dbc-pest/src/lib.rs:15
  variant Rule::empty_line, previously in file /tmp/.tmpW2nKdO/can-dbc-pest/src/lib.rs:15
  variant Rule::comment_line, previously in file /tmp/.tmpW2nKdO/can-dbc-pest/src/lib.rs:15
  variant Rule::section_header_line, previously in file /tmp/.tmpW2nKdO/can-dbc-pest/src/lib.rs:15

--- warning partial_ord_enum_variants_reordered: enum variants reordered in #[derive(PartialOrd)] enum ---

Description:
A public enum that derives PartialOrd had its variants reordered. #[derive(PartialOrd)] uses the enum variant order to set the enum's ordering behavior, so this change may break downstream code that relies on the previous order.
        ref: https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html#derivable
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/partial_ord_enum_variants_reordered.ron

Failed in:
  Rule::number moved from position 7 to 9, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::string moved from position 8 to 10, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::char moved from position 9 to 12, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::version moved from position 12 to 15, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::new_symbols moved from position 13 to 16, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::bit_timing moved from position 14 to 17, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::nodes moved from position 15 to 18, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::message moved from position 16 to 19, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::signal moved from position 17 to 20, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::comment moved from position 18 to 21, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::attr_def moved from position 19 to 22, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::attr_value moved from position 20 to 23, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::value_table_def moved from position 21 to 24, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::value_table moved from position 22 to 25, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::signal_group moved from position 23 to 26, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::signal_value_type moved from position 24 to 27, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::bo_tx_bu moved from position 25 to 28, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::ba_def_rel moved from position 26 to 29, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::ba_rel moved from position 27 to 30, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::ba_def_def_rel moved from position 28 to 31, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::ba_def_def moved from position 29 to 32, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::sg_mul_val moved from position 30 to 33, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
  Rule::environment_variable moved from position 31 to 34, in /tmp/.tmpRFBM9i/can-dbc-pest/src/lib.rs:15
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/oxibus/can-dbc-pest/compare/v0.1.1...v0.2.0) - 2025-10-07

### Fixed

- improve pest, pass openocd ([#4](https://github.com/oxibus/can-dbc-pest/pull/4))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).