### PR TITLE
chore: release v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2](https://github.com/oxibus/can-dbc-pest/compare/v0.7.1...v0.7.2) - 2026-01-21
+
+### Other
+
+- [pre-commit.ci] pre-commit autoupdate ([#33](https://github.com/oxibus/can-dbc-pest/pull/33))
+- adjust whitespace rules ([#34](https://github.com/oxibus/can-dbc-pest/pull/34))
+- rework testing framework, minor cleanups ([#32](https://github.com/oxibus/can-dbc-pest/pull/32))
+- update snapshot handling and improve justfile commands ([#31](https://github.com/oxibus/can-dbc-pest/pull/31))
+- *(deps)* bump actions/checkout from 5 to 6 in the all-actions-version-updates group ([#30](https://github.com/oxibus/can-dbc-pest/pull/30))
+- minor justfile fixes
+- minor justfile fixes
+
 ## [0.7.1](https://github.com/oxibus/can-dbc-pest/compare/v0.7.0...v0.7.1) - 2025-11-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - rework testing framework, minor cleanups ([#32](https://github.com/oxibus/can-dbc-pest/pull/32))
 - update snapshot handling and improve justfile commands ([#31](https://github.com/oxibus/can-dbc-pest/pull/31))
 - *(deps)* bump actions/checkout from 5 to 6 in the all-actions-version-updates group ([#30](https://github.com/oxibus/can-dbc-pest/pull/30))
-- minor justfile fixes
-- minor justfile fixes
 
 ## [0.7.1](https://github.com/oxibus/can-dbc-pest/compare/v0.7.0...v0.7.1) - 2025-11-10
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "can-dbc-pest"
-version = "0.7.1"
+version = "0.7.2"
 description = "A Pest-based parser for the DBC format. The DBC format is used to exchange CAN network data."
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 categories = ["embedded", "encoding", "parsing"]


### PR DESCRIPTION



## 🤖 New release

* `can-dbc-pest`: 0.7.1 -> 0.7.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.2](https://github.com/oxibus/can-dbc-pest/compare/v0.7.1...v0.7.2) - 2026-01-21

### Other

- [pre-commit.ci] pre-commit autoupdate ([#33](https://github.com/oxibus/can-dbc-pest/pull/33))
- adjust whitespace rules ([#34](https://github.com/oxibus/can-dbc-pest/pull/34))
- rework testing framework, minor cleanups ([#32](https://github.com/oxibus/can-dbc-pest/pull/32))
- update snapshot handling and improve justfile commands ([#31](https://github.com/oxibus/can-dbc-pest/pull/31))
- *(deps)* bump actions/checkout from 5 to 6 in the all-actions-version-updates group ([#30](https://github.com/oxibus/can-dbc-pest/pull/30))
- minor justfile fixes
- minor justfile fixes
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).