### PR TITLE
chore: release v0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3](https://github.com/oxibus/can-dbc-pest/compare/v0.7.2...v0.7.3) - 2026-05-11
+
+### Other
+
+- *(deps)* bump the all-actions-version-updates group across 1 directory with 2 updates ([#36](https://github.com/oxibus/can-dbc-pest/pull/36))
+- Fix parsing of environment variables with multiple access nodes ([#37](https://github.com/oxibus/can-dbc-pest/pull/37))
+
 ## [0.7.2](https://github.com/oxibus/can-dbc-pest/compare/v0.7.1...v0.7.2) - 2026-01-21
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.7.3](https://github.com/oxibus/can-dbc-pest/compare/v0.7.2...v0.7.3) - 2026-05-11
+## [0.8.0](https://github.com/oxibus/can-dbc-pest/compare/v0.7.2...v0.8.0) - 2026-05-11
 
 ### Other
 
-- *(deps)* bump the all-actions-version-updates group across 1 directory with 2 updates ([#36](https://github.com/oxibus/can-dbc-pest/pull/36))
 - Fix parsing of environment variables with multiple access nodes ([#37](https://github.com/oxibus/can-dbc-pest/pull/37))
+- Bump to Pest 2.8.6 which has a slightly different Debug output ([#37](https://github.com/oxibus/can-dbc-pest/pull/37))
+- *(deps)* bump the all-actions-version-updates group across 1 directory with 2 updates ([#36](https://github.com/oxibus/can-dbc-pest/pull/36))
 
 ## [0.7.2](https://github.com/oxibus/can-dbc-pest/compare/v0.7.1...v0.7.2) - 2026-01-21
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "can-dbc-pest"
-version = "0.7.2"
+version = "0.7.3"
 description = "A Pest-based parser for the DBC format. The DBC format is used to exchange CAN network data."
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 categories = ["embedded", "encoding", "parsing"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "can-dbc-pest"
-version = "0.7.3"
+version = "0.8.0"
 description = "A Pest-based parser for the DBC format. The DBC format is used to exchange CAN network data."
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 categories = ["embedded", "encoding", "parsing"]


### PR DESCRIPTION



## 🤖 New release

* `can-dbc-pest`: 0.7.2 -> 0.7.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.3](https://github.com/oxibus/can-dbc-pest/compare/v0.7.2...v0.7.3) - 2026-05-11

### Other

- *(deps)* bump the all-actions-version-updates group across 1 directory with 2 updates ([#36](https://github.com/oxibus/can-dbc-pest/pull/36))
- Fix parsing of environment variables with multiple access nodes ([#37](https://github.com/oxibus/can-dbc-pest/pull/37))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).