### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1](https://github.com/oxibus/can-dbc-pest/compare/v0.8.0...v0.8.1) - 2026-07-15
+
+### Other
+
+- update clippy, fmt, just ([#43](https://github.com/oxibus/can-dbc-pest/pull/43))
+- *(deps)* bump codecov/codecov-action from 6 to 7 in the all-actions-version-updates group ([#40](https://github.com/oxibus/can-dbc-pest/pull/40))
+
 ## [0.8.0](https://github.com/oxibus/can-dbc-pest/compare/v0.7.2...v0.8.0) - 2026-05-11
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "can-dbc-pest"
-version = "0.8.0"
+version = "0.8.1"
 description = "A Pest-based parser for the DBC format. The DBC format is used to exchange CAN network data."
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/oxibus/can-dbc-pest"


### PR DESCRIPTION



## 🤖 New release

* `can-dbc-pest`: 0.8.0 -> 0.8.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.1](https://github.com/oxibus/can-dbc-pest/compare/v0.8.0...v0.8.1) - 2026-07-15

### Other

- update clippy, fmt, just ([#43](https://github.com/oxibus/can-dbc-pest/pull/43))
- *(deps)* bump codecov/codecov-action from 6 to 7 in the all-actions-version-updates group ([#40](https://github.com/oxibus/can-dbc-pest/pull/40))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).